### PR TITLE
Fix: マニフェストファイルとテーマカラーの設定を追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,6 +49,10 @@
   <!-- Apple Touch Icon -->
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
+  <!-- Android Touch Icon -->
+  <link rel="icon" sizes="192x192" href="/icon-192.png">
+  <link rel="icon" sizes="512x512" href="/icon-512.png">
+
   <!-- Web App Manifest -->
   <link rel="manifest" href="/manifest.webmanifest">
 </head>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,4 +1,10 @@
 {
+  "name": "WaveConGra",
+  "short_name": "W",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#e0f2fe",
+  "theme_color": "#38bdf8",
   "icons": [
     {
       "src": "/icon-192.png",


### PR DESCRIPTION
manifest.webmanifestファイルにtheme_colorプロパティを追加し、値を#38BDF8に設定。

HTMLヘッダーにtheme-colorメタタグを追加。