### PR TITLE
Change: ダイレクトポストと返信の通知処理をコントローラに移動

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -32,7 +32,7 @@ class PostsController < ApplicationController
     @post = current_user.posts.build(post_params.except(:recipient_ids))
     if @post.save
       create_post_users(@post) if params[:post][:recipient_ids].present?
-      notify_async(@post, 'direct_post') if @post.privacy == 'selected_users'
+      notify_async(@post, 'direct') if @post.privacy == 'selected_users'
 
       flash[:notice] = t('defaults.flash_message.created', item: Post.model_name.human, default: '投稿が作成されました。')
       redirect_to user_post_path(current_user.username_slug, @post)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -30,8 +30,10 @@ class PostsController < ApplicationController
 
   def create
     @post = current_user.posts.build(post_params.except(:recipient_ids))
-    @post.recipient_ids = post_params[:recipient_ids] if post_params[:recipient_ids].present?
     if @post.save
+      create_post_users(@post) if params[:post][:recipient_ids].present?
+      notify_async(@post, 'direct_post') if @post.privacy == 'selected_users'
+
       flash[:notice] = t('defaults.flash_message.created', item: Post.model_name.human, default: '投稿が作成されました。')
       redirect_to user_post_path(current_user.username_slug, @post)
     else
@@ -45,8 +47,7 @@ class PostsController < ApplicationController
       flash[:notice] = t('defaults.flash_message.updated', item: Post.model_name.human, default: '投稿が更新されました。')
       redirect_to user_post_path(current_user.username_slug, @post)
     else
-      flash.now[:danger] =
-        t('defaults.flash_message.not_updated', item: Post.model_name.human, default: '投稿の更新に失敗しました。')
+      flash.now[:danger] = t('defaults.flash_message.not_updated', item: Post.model_name.human, default: '投稿の更新に失敗しました。')
       render :edit, status: :unprocessable_entity
     end
   end
@@ -84,6 +85,18 @@ class PostsController < ApplicationController
   # 投稿のパラメータを許可する
   def post_params
     params.require(:post).permit(:user_id, :body, :audio, :duration, :privacy, :post_reply_id, recipient_ids: [])
+  end
+
+  # 投稿に関連するユーザーを作成する
+  def create_post_users(post)
+    params[:post][:recipient_ids].each do |recipient_id|
+      post.post_users.create(user_id: recipient_id, role: 'direct_recipient')
+    end
+  end
+
+  # 非同期通知を実行する
+  def notify_async(post, notification_type)
+    NotificationJob.perform_later(notification_type, post.id)
   end
 
   # フォローしているユーザーを投稿数でソートする

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -10,6 +10,7 @@ class RepliesController < ApplicationController
     @reply = @post.replies.build(reply_params)
     @reply.user = current_user
     if @reply.save
+      notify_async(@reply, 'reply')
       flash[:notice] = '返信しました！'
     else
       flash.now[:danger] = 'お手数をおかけします。返信できませんでした。'
@@ -21,6 +22,7 @@ class RepliesController < ApplicationController
     @reply = @post.replies.build(reply_params)
     @reply.user = current_user
     if @reply.save
+      notify_async(@reply, 'reply')
       flash[:notice] = '返信しました！'
       respond_to do |format|
         format.turbo_stream
@@ -43,5 +45,10 @@ class RepliesController < ApplicationController
 
   def reply_params
     params.require(:post).permit(:user_id, :body, :audio, :duration, :privacy).merge(post_reply_id: @post.id)
+  end
+
+  # 非同期通知を実行する
+  def notify_async(post, notification_type)
+    NotificationJob.perform_later(notification_type, post.id)
   end
 end

--- a/app/jobs/notification_job.rb
+++ b/app/jobs/notification_job.rb
@@ -10,9 +10,9 @@ class NotificationJob < ApplicationJob
       post.create_notification_reply(post.user)
       Rails.logger.info "Notification created for reply: #{post.id}"
       UserMailer.reply_notification(post.parent_post.user, post).deliver_later
-    when 'direct_post'
+    when 'direct'
       post.create_notification_post(post.user)
-      Rails.logger.info "Notification created for direct_post: #{post.id}"
+      Rails.logger.info "Notification created for direct: #{post.id}"
       post.post_users.each do |post_user|
         UserMailer.direct_notification(post_user.user, post).deliver_later
       end

--- a/app/models/concerns/posts/notification.rb
+++ b/app/models/concerns/posts/notification.rb
@@ -53,7 +53,7 @@ module Posts
             recipient_id:, # 通知の受信者
             sender_id: current_user.id, # 通知の送信者
             notifiable: self, # 投稿
-            action: 'direct_post', # アクションタイプ
+            action: 'direct', # アクションタイプ
             unread: true # 未読状態
           )
           notification.save if notification.valid?

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -34,7 +34,7 @@
       <% end %>
       <span class="text-sm sm:text-lg">さんがあなたをフォローしました。</span>
     </div>
-  <% elsif notification.action == 'direct_post' %>
+  <% elsif notification.action == 'direct' %>
     <div class="flex items-center p-2">
       <i class="fa-regular fa-envelope text-orange-400 text-xl sm:text-3xl"></i>
       <%= link_to profile_show_path(username_slug: notification.sender.username_slug), data: { turbo_frame: "_top" } do %>


### PR DESCRIPTION
通知処理をモデルからコントローラに移動し、PostおよびRepliesコントローラで設定と通知の作成を行うようにしました。

理由: コントローラはリクエスト処理とアクションの結果として必要な後続処理を担当するべきであり、通知トリガーのような処理はコントローラに移動することで責任分担が明確になり、コードの可読性と保守性が向上します。さらに、異なる条件やタイミングでの通知トリガーが容易になるため、柔軟性も向上します。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced post creation with recipient-specific notifications.
  - Added asynchronous notifications for replies.

- **Bug Fixes**
  - Improved flash message handling during post updates.

- **Refactor**
  - Moved notification handling from the Post model to controllers for better separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->