### PR TITLE
fix: 詳細ページで親投稿が二重に表示される問題を修正

### DIFF
--- a/app/views/posts/_show.html.erb
+++ b/app/views/posts/_show.html.erb
@@ -16,12 +16,14 @@
         </div>
 
         <div class="bg-white">
-          <% if @post.parent_post.present? %>
-            <%= render 'posts/post', post: @post.parent_post %>
-          <% elsif @post.post_reply_id.present? %>
-            <div class="text-lg text-gray-500 mb-2">
-              親の投稿が削除されました。
-            </div>
+          <% unless @parent_posts.include?(@post.parent_post) %>
+            <% if @post.parent_post.present? %>
+              <%= render 'posts/post', post: @post.parent_post %>
+            <% elsif @post.post_reply_id.present? %>
+              <div class="text-lg text-gray-500 mb-2">
+                親の投稿が削除されました。
+              </div>
+            <% end %>
           <% end %>
           <%= render 'posts/post', post: @post %>
         </div>

--- a/app/views/posts/shared/_footer.html.erb
+++ b/app/views/posts/shared/_footer.html.erb
@@ -3,11 +3,13 @@
   <div id="post-<%= post.id %>-reply-icon">
     <%= render 'posts/reply_icon', post: post %>
   </div>
-  <div>
-    <%= turbo_frame_tag "post-#{post.id}-repost" do %>
-      <%= render 'posts/repost_icon', post: post %>
-    <% end %>
-  </div>
+  <% if post.open? %>
+    <div>
+      <%= turbo_frame_tag "post-#{post.id}-repost" do %>
+        <%= render 'posts/repost_icon', post: post %>
+      <% end %>
+    </div>
+  <% end %>
   <div>
     <%= turbo_frame_tag "post-#{post.id}-like" do %>
       <%= render 'posts/like', post: post %>

--- a/app/views/replies/new_modal.html.erb
+++ b/app/views/replies/new_modal.html.erb
@@ -13,16 +13,17 @@
         <% end %>
       </div>
       <div class="bg-white">
-        <% if @post.parent_post.present? %>
-          <%= render 'posts/post', post: @post.parent_post %>
-        <% elsif @post.post_reply_id.present? %>
-          <div class="text-lg text-gray-500 mb-2">
-            親の投稿が削除されました。
-          </div>
-        <% end %>
-
-        <%= render 'posts/post', post: @post %>
-      </div>
+          <% unless @parent_posts.include?(@post.parent_post) %>
+            <% if @post.parent_post.present? %>
+              <%= render 'posts/post', post: @post.parent_post %>
+            <% elsif @post.post_reply_id.present? %>
+              <div class="text-lg text-gray-500 mb-2">
+                親の投稿が削除されました。
+              </div>
+            <% end %>
+          <% end %>
+          <%= render 'posts/post', post: @post %>
+        </div>
       <%= render 'replies/form_modal', post: @post, reply: @reply %>
       <div class="modal-action">
         <button class="btn" data-action="reply-modal#closeModal">閉じる</button>


### PR DESCRIPTION
Postモデルの親投稿を適切に表示するために、@post.parent_postが@parent_postsに含まれているかチェックを追加